### PR TITLE
Added state support to callback

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -76,7 +76,8 @@ class FacebookStrategy extends OpauthStrategy{
 						'token' => $results['access_token'],
 						'expires' => date('c', time() + $results['expires'])
 					),
-					'raw' => $me
+					'raw' => $me,
+					'state' => $_GET['state']
 				);
 				
 				if (!empty($me->email)) $this->auth['info']['email'] = $me->email;


### PR DESCRIPTION
$opuath->get('auth.state') should return the state value, if passed  as part of the strategy
