### PR TITLE
[1.0] Fixed when token received has no expiration

### DIFF
--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -89,7 +89,7 @@ class Facebook extends AbstractStrategy
         $response = $this->response($me);
         $response->credentials = array(
             'token' => $results['access_token'],
-            'expires' => date('c', time() + $results['expires'])
+            'expires' => isset($results['expires']) ? date('c', time() + $results['expires']) : null
         );
         $response->info['image'] = 'https://graph.facebook.com/' . $me['id'] . '/picture?type=square';
         return $response;


### PR DESCRIPTION
If user grants a Facebook app the "manage_pages" permission and subsequently requests to get a page token, this page token and also the long-lived user tokenm used to perform that request, will both have no expiration and response will not contain the 'expires' param.

Related: 
- https://developers.facebook.com/docs/facebook-login/access-tokens/#extendingpagetokens
- https://developers.facebook.com/docs/roadmap/completed-changes/offline-access-removal/ (Scenario 5) 
