### PR TITLE
Remove nickname and change name to name

### DIFF
--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -29,11 +29,10 @@ class Facebook extends AbstractStrategy
      * @var array
      */
     public $responseMap = array(
-        'name' => 'username',
+        'name' => 'name',
         'uid' => 'id',
         'info.name' => 'name',
         'info.email' => 'email',
-        'info.nickname' => 'username',
         'info.first_name' => 'first_name',
         'info.last_name' => 'last_name',
         'info.location' => 'location.name',


### PR DESCRIPTION
Facebook has deprecated the username in the new version 2.0 of the Graph Api, so Opauth is throwing an error Invalid response, missing required parameters.

https://developers.facebook.com/docs/apps/changelog
