### PR TITLE
Fix callback to work with Graph API v2.3+

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -60,7 +60,7 @@ class FacebookStrategy extends OpauthStrategy{
 			);
 			$response = $this->serverGet($url, $params, null, $headers);
 			
-			parse_str($response, $results);
+			$results = json_decode($response, true);
 
 			if (!empty($results) && !empty($results['access_token'])){
 				$me = $this->me($results['access_token']);


### PR DESCRIPTION
As specified in the API changelog ( https://developers.facebook.com/docs/apps/changelog?locale=en_US ), the response format was changed to json.

> [Oauth Access Token] Format - The response format of https://www.facebook.com/v2.3/oauth/access_token returned when you exchange a code for an access_token now return valid JSON instead of being URL encoded. The new format of this response is {"access_token": {TOKEN}, "token_type":{TYPE}, "expires_in":{TIME}}. We made this update to be compliant with section 5.1 of RFC 6749.