### PR TITLE
Fix: Use correct error callback keys for fb v2.8, see #44

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -105,8 +105,8 @@ class FacebookStrategy extends OpauthStrategy{
 		else{
 			$error = array(
 				'provider' => 'Facebook',
-				'code' => $_GET['error'],
-				'message' => $_GET['error_description'],
+				'code' => $_GET['error_code'],
+				'message' => $_GET['error_message'],
 				'raw' => $_GET
 			);
 


### PR DESCRIPTION
This uses the correct keys in the `$_GET` response array for facebook v2.8 in case of an error response (API not available, failed, etc.).