### PR TITLE
fix error callback without error message

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -56,7 +56,7 @@ class FacebookStrategy extends OpauthStrategy{
 			$error = array(
 				'provider' => 'Facebook',
 				'code' => $_GET['error_code'],
-				'message' => $_GET['error_message'],
+				'message' => isset($_GET['error_message']) ? $_GET['error_message'] : '',
 				'raw' => $_GET
 			);
 


### PR DESCRIPTION
Sometimes Facebook send errors without 'error_message', as result we have messages in the logs like this:
PHP Notice:  Undefined index: error_message in /var/www/website/vendor/opauth/facebook/FacebookStrategy.php on line 59