### PR TITLE
Update to API Version 2.12

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -27,7 +27,7 @@ class FacebookStrategy extends OpauthStrategy{
 		'redirect_uri' => '{complete_url_to_strategy}int_callback'
 	);
 
-	private $api_version = 'v2.10';
+	private $api_version = 'v2.12';
 
 	/**
 	 * Auth request


### PR DESCRIPTION
API 2.10 will be retired soon. The methods used have not changed in 2.11 und 2.12.
2.12. will be available until 1st of May 2020.
This buys us some extra time to implement changes that where introduces in v3 like expiring tokens.