### PR TITLE
Update to API Version 6.0

### DIFF
--- a/FacebookStrategy.php
+++ b/FacebookStrategy.php
@@ -27,7 +27,7 @@ class FacebookStrategy extends OpauthStrategy{
 		'redirect_uri' => '{complete_url_to_strategy}int_callback'
 	);
 
-	private $api_version = 'v2.12';
+	private $api_version = 'v6.0';
 
 	/**
 	 * Auth request


### PR DESCRIPTION
API 2.12 will be retired soon. We compared responses from Facebook using API 2.12 and API 6.0 (the latest version)
==> We found no differences in the responses.